### PR TITLE
fix broken link fields

### DIFF
--- a/src/features/payload-cms/payload-cms/utils/link-field-logic.ts
+++ b/src/features/payload-cms/payload-cms/utils/link-field-logic.ts
@@ -53,7 +53,7 @@ export const getURLForLinkField = (linkFieldData?: LinkFieldDataType): string | 
     if (urlSlug === '') {
       return '/';
     }
-    return urlSlug;
+    return '/' + urlSlug;
   }
 
   return undefined;


### PR DESCRIPTION
currently, links in the navbar are only relative to the current opened url (without / in case of generic pages). therefore, if one visits a blog /blog/xy), the navbar then points to /blog/entry instead of /entry.

This PR fixes this.