### PR TITLE
fix(ui): resolve file download button cut-off in accordion (#1160)

### DIFF
--- a/src/features/payload-cms/components/content-blocks/file-download.tsx
+++ b/src/features/payload-cms/components/content-blocks/file-download.tsx
@@ -1,6 +1,6 @@
 import { LinkComponent } from '@/components/ui/link-component';
 import type { Locale } from '@/types/types';
-import { Paperclip } from 'lucide-react';
+import { Download, Paperclip } from 'lucide-react';
 import React from 'react';
 
 export interface FileDownloadType {
@@ -37,31 +37,31 @@ const dateStringToFormatedDate = (locale: Locale, dateString: string): string =>
 
 export const FileDownload: React.FC<FileDownloadType> = ({ locale, ...block }) => {
   return (
-    <div className="rounded-md border-2 border-gray-200 bg-white transition duration-200 hover:shadow-md sm:m-8">
+    <div className="group hover:border-conveniat-green/30 my-4 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-xs transition-all duration-300 hover:bg-green-50/10 hover:shadow-md sm:my-6">
       <LinkComponent
         href={block.file.url}
         openInNewTab={block.openInNewTab}
-        className="block p-2"
+        className="block p-3 sm:p-4"
         hideExternalIcon
       >
-        <div className="grid grid-cols-[auto_1fr_auto] items-center gap-2">
-          <Paperclip className="mx-2 h-4 w-4 text-green-400" />
-          <div className="flex flex-col overflow-hidden sm:flex-row sm:items-center sm:space-x-2">
-            <div className="flex flex-col">
-              <span className="text-conveniat-green truncate font-extrabold">
-                {block.file.filename}
-              </span>
-            </div>
-            <span className="text-conveniat-green text-xs sm:ml-2 sm:hidden">
-              ({formatBytes(block.file.filesize)},{' '}
-              {dateStringToFormatedDate(locale, block.file.updatedAt)})
-            </span>
+        <div className="grid grid-cols-[auto_1fr_auto] items-center gap-3 sm:gap-4">
+          <div className="text-conveniat-green flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-green-50 transition duration-300 group-hover:bg-green-100/60">
+            <Paperclip className="text-conveniat-green h-5 w-5" />
           </div>
-          <div className="hidden sm:flex sm:flex-col sm:items-end">
-            <span className="text-conveniat-green text-xs">
-              {formatBytes(block.file.filesize)},{' '}
+          <div className="flex min-w-0 flex-col">
+            <span
+              className="text-conveniat-green group-hover:text-conveniat-green/80 block truncate text-sm font-semibold transition duration-200"
+              title={block.file.filename}
+            >
+              {block.file.filename}
+            </span>
+            <span className="mt-0.5 text-xs text-gray-500">
+              {formatBytes(block.file.filesize)} •{' '}
               {dateStringToFormatedDate(locale, block.file.updatedAt)}
             </span>
+          </div>
+          <div className="group-hover:bg-conveniat-green flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-50 text-gray-400 transition-all duration-300 group-hover:scale-105 group-hover:text-white">
+            <Download className="h-4 w-4" />
           </div>
         </div>
       </LinkComponent>


### PR DESCRIPTION
This PR resolves the design issue (#1160) where long document names inside accordion elements were being cut off and clipped without an ellipsis.

### Root Cause
1. **Container Margin Squishing**: The component had `sm:m-8` on the parent, which applied a large margin to all sides on screens >= 640px. When inside an accordion, this horizontally squeezed the download block.
2. **Side-by-Side Flex Layout**: On standard/desktop viewports, the filename and file size/date details were displayed side-by-side. The file info occupied a large fixed width on the right, leaving very little space for the filename.
3. **Improper Truncation Hierarchy**: The wrapper for the filename lacked a `min-w-0` layout directive, preventing it from shrinking, and the parent container had `overflow-hidden` which raw-clipped the text boundary directly, preventing CSS ellipsis from triggering.

### Solution / Changes
- **Two-line Visual Hierarchy**: Replaced the side-by-side flex layout with a premium two-line hierarchy (filename on the top line, file size and updated date on the bottom line separated by a bullet `•`). This maximizes horizontal space for the filename, groups related metadata together, and completely prevents layout squishing inside narrow parent containers (like accordions).
- **Proper Text Truncation**: Applied proper layout constraints (`min-w-0 flex flex-col` and `block truncate`) to trigger the CSS ellipsis (`...`) gracefully for long filenames. Added a browser `title` tooltip so users can hover to view the full name.
- **Improved Spacing**: Replaced `sm:m-8` with vertical-only margins (`my-4 sm:my-6`), allowing the component to expand to the full width of its parent container.
- **Premium Aesthetics & Interactive Tactility**:
  - Left Icon: Enclosed the `Paperclip` icon in a brand-tinted circle/badge (`bg-green-50 text-conveniat-green`).
  - Right Icon: Added a dedicated circular interactive `Download` chevron/button. On hover, the button animates/transforms by scaling up and changing from a neutral gray state to brand green with a white icon.