### PR TITLE
fix(chat): resolve scroll issues in chat details and create modal

### DIFF
--- a/src/features/chat/components/chat-details-view/sections/add-participants.tsx
+++ b/src/features/chat/components/chat-details-view/sections/add-participants.tsx
@@ -105,7 +105,7 @@ export const AddParticipants: React.FC<AddParticipantsProperties> = ({
       )}
 
       {/* Contacts List */}
-      <div className="mb-4 h-[200px] space-y-1 overflow-y-auto rounded-md border p-2">
+      <div className="mb-4 space-y-1 rounded-md border p-2">
         {isLoadingContacts && (
           <div className="flex h-full items-center justify-center text-sm text-gray-500">
             <Loader2 className="mr-2 h-4 w-4 animate-spin" /> {loadingContactsText[locale]}

--- a/src/features/chat/components/chat-details-view/sections/participants-list.tsx
+++ b/src/features/chat/components/chat-details-view/sections/participants-list.tsx
@@ -71,7 +71,7 @@ export const ParticipantsList: React.FC<ParticipantsListProperties> = ({
         )}
       </div>
 
-      <div className="max-h-60 space-y-3 overflow-y-auto">
+      <div className="space-y-3">
         {participants.map((participant) => (
           <div key={participant.id} className="flex items-center justify-between gap-3">
             <div className="flex flex-1 items-center gap-3">

--- a/src/features/chat/components/chat-overview-view/create-chat-component.tsx
+++ b/src/features/chat/components/chat-overview-view/create-chat-component.tsx
@@ -181,7 +181,7 @@ export const CreateNewChatPage: React.FC = () => {
       </div>
 
       {/* Main Content */}
-      <div className="flex-1 overflow-y-auto p-4">
+      <div className="min-h-0 flex-1 overflow-y-auto p-4">
         <div className="mx-auto max-w-2xl space-y-6">
           {/* Group Chat Name Input */}
           {isGroupChat && (

--- a/src/features/chat/components/chat-view/chat-details.tsx
+++ b/src/features/chat/components/chat-view/chat-details.tsx
@@ -88,7 +88,7 @@ export const ChatDetails: React.FC = () => {
       />
 
       {/* Main Content */}
-      <div className="flex-1 overflow-y-auto px-4 py-12">
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-12">
         <div className="mx-auto max-w-2xl space-y-6">
           <ChatNameSection
             currentName={chatDetails.name}


### PR DESCRIPTION
Fixes #681

## Description
This PR resolves the scrolling issues in the Chat Details view and Chat Create Modal where:
1. The bottom section (e.g. Delete Chat button) was cut off and unreachable.
2. The user could not scroll when interacting directly over the chat participants/contacts list due to nested scroll trapping.

## Technical Details
- Added `min-h-0` to the `flex-1` wrapper containers in `chat-details.tsx` and `create-chat-component.tsx` to prevent the flex item from implicitly expanding past its parent's `h-dvh` bounds. This ensures the internal `overflow-y-auto` scrollbar is consistently triggered.
- Removed `max-h-60` / `h-[200px]` limits and `overflow-y-auto` from `ParticipantsList` and `AddParticipants`. Allowing these lists to expand naturally defers all scrolling to the parent `flex-1` container, resolving Safari nested scroll trapping issues.