### PR TITLE
fix(chat): resolve group chat read status badge desync

### DIFF
--- a/src/features/chat/hooks/use-message-read-status.ts
+++ b/src/features/chat/hooks/use-message-read-status.ts
@@ -2,7 +2,6 @@
 
 import type { ChatMessage } from '@/features/chat/api/types';
 import type { ChatWithMessagePreview } from '@/features/chat/types/api-dto-types';
-import { MessageEventType } from '@/lib/prisma/client';
 import { trpc } from '@/trpc/client';
 import { useEffect, useState } from 'react';
 
@@ -56,7 +55,6 @@ export const useMessageReadStatus = ({
 
       if (
         latestMessageToRead !== undefined &&
-        latestMessageToRead.status !== MessageEventType.READ &&
         (lastMarkedReadId === undefined || latestMessageToRead.id > lastMarkedReadId)
       ) {
         markChatAsRead({


### PR DESCRIPTION
Removes the global message-status matching condition to prevent read status desync across different users in group/support chats. Drive badges strictly using local watermark comparisons.