### PR TITLE
fix(chat): map unique optimisticMessageId to avoid multi-message collisions on concurrent sends

### DIFF
--- a/src/features/chat/hooks/use-admin-chat-management.ts
+++ b/src/features/chat/hooks/use-admin-chat-management.ts
@@ -101,14 +101,14 @@ export const useAdminChatManagement = ({
         };
       });
 
-      return { previousMessages };
+      return { previousMessages, optimisticMessageId: optimisticMessage.id };
     },
     onError: (_error, { chatId }, context) => {
       if (context?.previousMessages) {
         utils.admin.getChatMessages.setData({ chatId }, context.previousMessages);
       }
     },
-    onSuccess: (createdMessage, { chatId, content, type }) => {
+    onSuccess: (createdMessage, { chatId, content, type }, context) => {
       utils.admin.getChatMessages.setData({ chatId }, (old) => {
         if (!old) return old;
         const alreadyHasStored = old.messages.some((m) => m.id === createdMessage.uuid);
@@ -116,7 +116,11 @@ export const useAdminChatManagement = ({
           ...old,
           messages: old.messages
             .map((m) => {
-              if (m.id.startsWith('optimistic-')) {
+              const isMatch =
+                typeof context.optimisticMessageId === 'string'
+                  ? m.id === context.optimisticMessageId
+                  : m.id.startsWith('optimistic-');
+              if (isMatch) {
                 return alreadyHasStored
                   ? undefined
                   : {

--- a/src/features/chat/hooks/use-admin-chat-management.ts
+++ b/src/features/chat/hooks/use-admin-chat-management.ts
@@ -78,7 +78,7 @@ export const useAdminChatManagement = ({
       const currentUserId = previousMessages?.currentUserId ?? 'current-admin-user';
 
       const optimisticMessage = {
-        id: `optimistic-${Date.now()}`,
+        id: `optimistic-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
         createdAt: new Date(),
         messagePayload: type === MessageType.IMAGE_MSG ? { url: content } : { text: content },
         senderId: currentUserId,
@@ -116,9 +116,11 @@ export const useAdminChatManagement = ({
           ...old,
           messages: old.messages
             .map((m) => {
+              const optimisticId = (context as { optimisticMessageId?: string } | undefined)
+                ?.optimisticMessageId;
               const isMatch =
-                typeof context.optimisticMessageId === 'string'
-                  ? m.id === context.optimisticMessageId
+                typeof optimisticId === 'string'
+                  ? m.id === optimisticId
                   : m.id.startsWith('optimistic-');
               if (isMatch) {
                 return alreadyHasStored

--- a/src/features/chat/hooks/use-message-send.ts
+++ b/src/features/chat/hooks/use-message-send.ts
@@ -15,7 +15,7 @@ type UseMessageSendMutation = UseTRPCMutationResult<
   inferProcedureOutput<AppRouter['chat']['sendMessage']>,
   TRPCClientErrorLike<AppRouter>,
   inferProcedureInput<AppRouter['chat']['sendMessage']>,
-  unknown
+  OptimisticUpdateResult
 >;
 
 type InfiniteMessagesOutput = inferProcedureOutput<AppRouter['chat']['infiniteMessages']>;
@@ -24,6 +24,7 @@ type InfiniteMessagesData = InfiniteData<InfiniteMessagesOutput, string | null>;
 interface OptimisticUpdateResult {
   previousChatData: ChatDetails | undefined;
   previousInfiniteData: InfiniteMessagesData | undefined;
+  optimisticMessageId?: string;
 }
 
 const performOptimisticMessageUpdate = async (
@@ -167,7 +168,7 @@ const performOptimisticMessageUpdate = async (
     });
   });
 
-  return { previousChatData, previousInfiniteData };
+  return { previousChatData, previousInfiniteData, optimisticMessageId: optimisticMessage.id };
 };
 
 export const useMessageSend = (): UseMessageSendMutation => {
@@ -213,7 +214,7 @@ export const useMessageSend = (): UseMessageSendMutation => {
       }
     },
 
-    onSuccess: (createdMessageData, { chatId }) => {
+    onSuccess: (createdMessageData, { chatId }, context) => {
       const createdMessage = createdMessageData as unknown as ChatMessage | undefined;
       if (createdMessage === undefined) return;
 
@@ -232,7 +233,11 @@ export const useMessageSend = (): UseMessageSendMutation => {
               ...page,
               items: page.items
                 .map((item) => {
-                  if (item.id.startsWith('optimistic-')) {
+                  const isMatch =
+                    typeof context.optimisticMessageId === 'string'
+                      ? item.id === context.optimisticMessageId
+                      : item.id.startsWith('optimistic-');
+                  if (isMatch) {
                     return alreadyHasStored ? undefined : createdMessage;
                   }
                   return item;
@@ -255,7 +260,11 @@ export const useMessageSend = (): UseMessageSendMutation => {
             ...oldData,
             messages: oldData.messages
               .map((item) => {
-                if (item.id.startsWith('optimistic-')) {
+                const isMatch =
+                  typeof context.optimisticMessageId === 'string'
+                    ? item.id === context.optimisticMessageId
+                    : item.id.startsWith('optimistic-');
+                if (isMatch) {
                   return alreadyHasStored ? undefined : createdMessage;
                 }
                 return item;

--- a/src/features/chat/hooks/use-message-send.ts
+++ b/src/features/chat/hooks/use-message-send.ts
@@ -70,7 +70,7 @@ const performOptimisticMessageUpdate = async (
   }
 
   const optimisticMessage: ChatMessage = {
-    id: `optimistic-${Date.now()}`,
+    id: `optimistic-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
     messagePayload: {
       text: content.trim(),
       ...(typeof quotedMessageId === 'string' &&
@@ -233,9 +233,11 @@ export const useMessageSend = (): UseMessageSendMutation => {
               ...page,
               items: page.items
                 .map((item) => {
+                  const optimisticId = (context as OptimisticUpdateResult | undefined)
+                    ?.optimisticMessageId;
                   const isMatch =
-                    typeof context.optimisticMessageId === 'string'
-                      ? item.id === context.optimisticMessageId
+                    typeof optimisticId === 'string'
+                      ? item.id === optimisticId
                       : item.id.startsWith('optimistic-');
                   if (isMatch) {
                     return alreadyHasStored ? undefined : createdMessage;
@@ -260,9 +262,11 @@ export const useMessageSend = (): UseMessageSendMutation => {
             ...oldData,
             messages: oldData.messages
               .map((item) => {
+                const optimisticId = (context as OptimisticUpdateResult | undefined)
+                  ?.optimisticMessageId;
                 const isMatch =
-                  typeof context.optimisticMessageId === 'string'
-                    ? item.id === context.optimisticMessageId
+                  typeof optimisticId === 'string'
+                    ? item.id === optimisticId
                     : item.id.startsWith('optimistic-');
                 if (isMatch) {
                   return alreadyHasStored ? undefined : createdMessage;


### PR DESCRIPTION
Introduces unique context-based optimisticMessageId checking in TanStack Query's onSuccess handler, completely preventing consecutive sends from overwriting each other in the UI and cache.