### PR TITLE
fix(chat): touch parent chat lastUpdate timestamp when emergency alert questions are answered

### DIFF
--- a/src/features/chat/api/mutations/update-message-content.ts
+++ b/src/features/chat/api/mutations/update-message-content.ts
@@ -122,6 +122,12 @@ export const updateMessageContent = trpcBaseProcedure
               },
         });
 
+        // Touch the parent chat to update lastUpdate timestamp
+        await prisma.chat.update({
+          where: { uuid: message.chatId },
+          data: { lastUpdate: new Date() },
+        });
+
         // Publish new_message event for the new question/response
         chatPubSub
           .publish({

--- a/src/features/chat/api/mutations/update-message-content.ts
+++ b/src/features/chat/api/mutations/update-message-content.ts
@@ -52,7 +52,16 @@ export const updateMessageContent = trpcBaseProcedure
     });
 
     // Check if this was an alert question being answered
-    if (message.type === MessageType.ALERT_QUESTION && content['selectedOption']) {
+    if (
+      message.type === MessageType.ALERT_QUESTION &&
+      typeof content['selectedOption'] === 'string'
+    ) {
+      // Touch the parent chat to update lastUpdate timestamp
+      await prisma.chat.update({
+        where: { uuid: message.chatId },
+        data: { lastUpdate: new Date() },
+      });
+
       const { getPayload } = await import('payload');
       const config = await import('@payload-config');
       const payloadAPI = await getPayload({ config: config.default });
@@ -63,7 +72,7 @@ export const updateMessageContent = trpcBaseProcedure
         fallbackLocale: 'de',
       });
 
-      const questions = alertSettings.questions || [];
+      const questions = alertSettings.questions ?? [];
       const currentQuestionIndex = questions.findIndex((q) => q.id === content['questionRefId']);
 
       if (currentQuestionIndex !== -1) {
@@ -120,12 +129,6 @@ export const updateMessageContent = trpcBaseProcedure
                   create: [{ type: 'STORED' }],
                 },
               },
-        });
-
-        // Touch the parent chat to update lastUpdate timestamp
-        await prisma.chat.update({
-          where: { uuid: message.chatId },
-          data: { lastUpdate: new Date() },
         });
 
         // Publish new_message event for the new question/response


### PR DESCRIPTION
Touch the parent support chat with an updated lastUpdate timestamp when emergency alert questions are created or answered, allowing active chats to correctly bubble up in sidebar listing views.