### PR TITLE
fix(chat): invoke cleanup() inside sse heartbeat keepAliveInterval catch block to prevent connection leak

### DIFF
--- a/src/app/(frontend)/api/chat/sse/route.ts
+++ b/src/app/(frontend)/api/chat/sse/route.ts
@@ -96,6 +96,7 @@ export async function GET(request: NextRequest): Promise<Response> {
           controller.enqueue(encoder.encode(':keepalive\n\n'));
         } catch {
           // Stream might be already closed, handled in cancel/abort
+          cleanup();
         }
       }, 30_000);
 


### PR DESCRIPTION
Guarantees clean connection heartbeat timer interval clearance in SSE route.ts by invoking cleanup() directly if the keepalive heartbeat write to stream fails.