### PR TITLE
feat(chat): fix web share target parameter persistence (#519)

### DIFF
--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -45,6 +45,7 @@ import { ImportListMenuItem as ImportListMenuItem_cdf7e044479f899a31f804427d568b
 import { default as default_c9f917d9608a57eb8358fce7a7898bd3 } from '@/features/payload-cms/payload-cms/components/push-notification/push-notification'
 import { default as default_7d02a833b9164544e9c8d7653b246eb7 } from '@/features/payload-cms/components/push-notification/push-notification-history.tsx'
 import { ResendEmailButton as ResendEmailButton_e62af8aa593181d6540c08021abb9c8b } from '@/features/payload-cms/payload-cms/components/resend-email/resend-email-button'
+import { OverrideStatusButton as OverrideStatusButton_8c304667b297b7e538d558abfba16bf0 } from '@/features/payload-cms/payload-cms/components/override-status/override-status-button'
 import { default as default_30bb34ba732976b67b42694b834628a5 } from '@/features/payload-cms/payload-cms/components/email-preview/email-preview-field'
 import { default as default_5ef9787d26b4ecd448f299564fb6b977 } from '@/features/payload-cms/payload-cms/components/smtp-results/smtp-results-cell'
 import { default as default_a06f68e0cdad6b2fba6e2223cd5b6303 } from '@/features/payload-cms/payload-cms/components/smtp-results/smtp-results-field'
@@ -149,6 +150,7 @@ export const importMap = {
   "@/features/payload-cms/payload-cms/components/push-notification/push-notification#default": default_c9f917d9608a57eb8358fce7a7898bd3,
   "@/features/payload-cms/components/push-notification/push-notification-history.tsx#default": default_7d02a833b9164544e9c8d7653b246eb7,
   "@/features/payload-cms/payload-cms/components/resend-email/resend-email-button#ResendEmailButton": ResendEmailButton_e62af8aa593181d6540c08021abb9c8b,
+  "@/features/payload-cms/payload-cms/components/override-status/override-status-button#OverrideStatusButton": OverrideStatusButton_8c304667b297b7e538d558abfba16bf0,
   "@/features/payload-cms/payload-cms/components/email-preview/email-preview-field#default": default_30bb34ba732976b67b42694b834628a5,
   "@/features/payload-cms/payload-cms/components/smtp-results/smtp-results-cell#default": default_5ef9787d26b4ecd448f299564fb6b977,
   "@/features/payload-cms/payload-cms/components/smtp-results/smtp-results-field#default": default_a06f68e0cdad6b2fba6e2223cd5b6303,

--- a/src/features/chat/components/chat-view/chat-text-area-input/hooks/use-message-input.ts
+++ b/src/features/chat/components/chat-view/chat-text-area-input/hooks/use-message-input.ts
@@ -87,10 +87,27 @@ export const useMessageInput = (): UseMessageInputLogicResult => {
           // Message sent successfully, clear the pending message ref
           pendingMessageReference.current = undefined;
           if (quotedMessageId) cancelQuote();
+
+          // Clear shared query parameters from the URL
+          if ('history' in globalThis && 'location' in globalThis) {
+            const url = new globalThis.URL(globalThis.location.href);
+            const hasText = url.searchParams.has('text');
+            const hasTitle = url.searchParams.has('title');
+            const hasUrl = url.searchParams.has('url');
+            if (hasText || hasTitle || hasUrl) {
+              url.searchParams.delete('text');
+              url.searchParams.delete('title');
+              url.searchParams.delete('url');
+              globalThis.history.replaceState({}, '', url.pathname + url.search);
+            }
+          }
         },
         onError: (error) => {
           // Restore the message on error so user can retry
-          if (pendingMessageReference.current) {
+          if (
+            pendingMessageReference.current !== undefined &&
+            pendingMessageReference.current !== ''
+          ) {
             setNewMessage(pendingMessageReference.current);
             pendingMessageReference.current = undefined;
           }

--- a/src/features/chat/components/chat-view/chat-text-area-input/hooks/use-message-input.ts
+++ b/src/features/chat/components/chat-view/chat-text-area-input/hooks/use-message-input.ts
@@ -98,7 +98,11 @@ export const useMessageInput = (): UseMessageInputLogicResult => {
               url.searchParams.delete('text');
               url.searchParams.delete('title');
               url.searchParams.delete('url');
-              globalThis.history.replaceState({}, '', url.pathname + url.search);
+              globalThis.history.replaceState(
+                globalThis.history.state,
+                '',
+                url.pathname + url.search,
+              );
             }
           }
         },

--- a/src/utils/generate-manifest.ts
+++ b/src/utils/generate-manifest.ts
@@ -78,7 +78,7 @@ export const cachedManifestGenerator = async (): Promise<MetadataRoute.Manifest>
       scope: '/',
       prefer_related_applications: false,
       share_target: {
-        action: '/entrypoint',
+        action: '/entrypoint?app-mode=true',
         method: 'GET',
         enctype: 'application/x-www-form-urlencoded',
         params: {


### PR DESCRIPTION
Closes #519.

### Problem
1. **Web Share Design Reset:** When using the Web Share Target, the PWA was launched with an action URL of `/entrypoint`. This did not specify `app-mode=true`, causing the Next.js router/design proxy to fall back to the default web layout design instead of the intended PWA standalone App design.
2. **Search Parameters Persistence:** Shared parameters (`text`, `title`, `url`) from the Web Share Target persisted in the URL even after the message was successfully typed and sent. Navigating back or re-entering the page would populate the textarea again.

### Solution
1. **PWA Manifest Action:** Updated the web share target action in `src/utils/generate-manifest.ts` to `/entrypoint?app-mode=true`. This guarantees that whenever the PWA is launched as a share target, it boots directly in App Design Mode.
2. **Parameter Clearance:** Updated the `useMessageInput` hook to programmatically clear the `text`, `title`, and `url` search parameters from the URL upon successful message dispatch using browser history state replacement (`globalThis.history.replaceState`).