### PR TITLE
fix(chat): prevent standard users and owners from archiving announcement chats

### DIFF
--- a/src/features/chat/api/checks/can-user-archive-chat.ts
+++ b/src/features/chat/api/checks/can-user-archive-chat.ts
@@ -17,6 +17,10 @@ export const canUserArchiveChat = (
     chatMemberships: { userId: string; chatPermission: ChatMembershipPermission }[];
   },
 ): boolean => {
+  if (chat.type === ChatType.ANNOUNCEMENT) {
+    return false;
+  }
+
   const userUuid = user.uuid;
 
   const chatMemberships = chat.chatMemberships;

--- a/src/features/chat/components/chat-overview-view/swipe-to-delete-chat.tsx
+++ b/src/features/chat/components/chat-overview-view/swipe-to-delete-chat.tsx
@@ -23,10 +23,14 @@ export const SwipeToDeleteChat: React.FC<SwipeToDeleteChatProperties> = ({ chat,
   const [isDeleting, setIsDeleting] = useState(false);
 
   const canDelete =
-    chat.chatType === ChatType.EMERGENCY ||
-    (
-      [ChatMembershipPermission.OWNER, ChatMembershipPermission.ADMIN] as ChatMembershipPermission[]
-    ).includes(chat.userChatPermission);
+    chat.chatType !== ChatType.ANNOUNCEMENT &&
+    (chat.chatType === ChatType.EMERGENCY ||
+      (
+        [
+          ChatMembershipPermission.OWNER,
+          ChatMembershipPermission.ADMIN,
+        ] as ChatMembershipPermission[]
+      ).includes(chat.userChatPermission));
 
   const binOpacity = useTransform(draggingX, [0, 50], [0, 1]);
   const binScale = useTransform(draggingX, [0, 100], [0.8, 1.2]);

--- a/src/features/chat/components/chat-view/chat-details.tsx
+++ b/src/features/chat/components/chat-view/chat-details.tsx
@@ -140,9 +140,11 @@ export const ChatDetails: React.FC = () => {
           <ChatCapabilities capabilities={chatDetails.capabilities} locale={locale} />
 
           {/* --- Archive Chat Section --- */}
-          <div className="rounded-lg border border-gray-200 bg-white p-6">
-            <DeleteChat />
-          </div>
+          {chatDetails.type !== 'ANNOUNCEMENT' && (
+            <div className="rounded-lg border border-gray-200 bg-white p-6">
+              <DeleteChat />
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/features/chat/components/chat-view/chat-details.tsx
+++ b/src/features/chat/components/chat-view/chat-details.tsx
@@ -17,6 +17,7 @@ import { useAddParticipants } from '@/features/chat/hooks/use-add-participants';
 import { useSuspenseChatDetail } from '@/features/chat/hooks/use-chats';
 import { useRemoveParticipants } from '@/features/chat/hooks/use-remove-participant';
 import { useUpdateChatMutation } from '@/features/chat/hooks/use-update-chat-mutation';
+import { ChatType } from '@/lib/prisma/client';
 import { trpc } from '@/trpc/client';
 import type { Locale } from '@/types/types';
 import { i18nConfig } from '@/types/types';
@@ -50,6 +51,8 @@ export const ChatDetails: React.FC = () => {
   }, [allContacts, chatDetails, searchQuery]);
 
   const isGroupChat = chatDetails.participants.length > 2;
+  const isAnnouncement = chatDetails.type === ChatType.ANNOUNCEMENT;
+  const isCourseGroup = chatDetails.type === ChatType.COURSE_GROUP;
 
   // --- Start of new handlers for participant management ---
   const handleToggleContactSelection = (contact: Contact): void => {
@@ -100,7 +103,7 @@ export const ChatDetails: React.FC = () => {
             }}
           />
 
-          {chatDetails.type === 'COURSE_GROUP' &&
+          {isCourseGroup &&
             chatDetails.courseId !== null &&
             chatDetails.courseId !== undefined &&
             chatDetails.courseId !== '' && (
@@ -108,7 +111,7 @@ export const ChatDetails: React.FC = () => {
             )}
 
           {/* --- Participants Section --- */}
-          {chatDetails.type !== 'ANNOUNCEMENT' && (
+          {!isAnnouncement && (
             <ParticipantsList
               participants={chatDetails.participants}
               currentUser={currentUser ?? ''}
@@ -122,7 +125,7 @@ export const ChatDetails: React.FC = () => {
           )}
 
           {/* --- Add Participants Section (Visible only when managing) --- */}
-          {chatDetails.type !== 'ANNOUNCEMENT' && isManagingParticipants && (
+          {!isAnnouncement && isManagingParticipants && (
             <AddParticipants
               searchQuery={searchQuery}
               onSearchChange={setSearchQuery}
@@ -140,7 +143,7 @@ export const ChatDetails: React.FC = () => {
           <ChatCapabilities capabilities={chatDetails.capabilities} locale={locale} />
 
           {/* --- Archive Chat Section --- */}
-          {chatDetails.type !== 'ANNOUNCEMENT' && (
+          {!isAnnouncement && (
             <div className="rounded-lg border border-gray-200 bg-white p-6">
               <DeleteChat />
             </div>

--- a/src/features/chat/hooks/use-user-can-archive.ts
+++ b/src/features/chat/hooks/use-user-can-archive.ts
@@ -10,6 +10,8 @@ export const useUserCanArchiveChat = (chatId: string): boolean => {
   const chatData = trpcUtils.chat.chatDetails.getData({ chatId: chatId });
   if (!chatData) return false;
 
+  if (chatData.type === ChatType.ANNOUNCEMENT) return false;
+
   if (chatData.type === ChatType.EMERGENCY) return true;
 
   // check permission of user


### PR DESCRIPTION
Disables standard users and owners from archiving or deleting ANNOUNCEMENT chats directly within the application (via swipe-to-delete or from the chat details screen). Announcement chats can only be deleted/archived via the admin panel.