### PR TITLE
fix(admin): prevent chat list sidebar scroll reset and loading skeleton flash

### DIFF
--- a/src/features/chat/components/admin/chat-management-messages.tsx
+++ b/src/features/chat/components/admin/chat-management-messages.tsx
@@ -1,6 +1,7 @@
 import type { ChatMessage } from '@/features/chat/api/types';
 import { MessageComponent } from '@/features/chat/components/chat-view/message';
 import type { ChatType } from '@/lib/prisma/client';
+import type { Locale } from '@/types/types';
 import { Loader2 } from 'lucide-react';
 import React, { useEffect, useRef } from 'react';
 
@@ -88,6 +89,7 @@ export const ChatManagementMessages: React.FC<ChatManagementMessagesProperties> 
                       message={message}
                       isCurrentUser={isCurrentUser}
                       chatType={chatType}
+                      locale={locale as Locale}
                     />
                   </div>
                 );

--- a/src/features/chat/components/admin/chat-management-sidebar.tsx
+++ b/src/features/chat/components/admin/chat-management-sidebar.tsx
@@ -45,8 +45,15 @@ export const ChatManagementSidebar: React.FC<ChatManagementSidebarProperties> = 
     }
   };
 
+  const hasRestoredScrollReference = React.useRef(false);
+
   React.useEffect(() => {
-    if (!loadingChats && scrollContainerReference.current) {
+    hasRestoredScrollReference.current = false;
+  }, [title]);
+
+  React.useEffect(() => {
+    if (!loadingChats && scrollContainerReference.current && !hasRestoredScrollReference.current) {
+      hasRestoredScrollReference.current = true;
       const saved = sessionStorage.getItem(`chat-sidebar-scroll-${title}`);
       if (saved !== null && saved !== '') {
         const container = scrollContainerReference.current;
@@ -56,7 +63,7 @@ export const ChatManagementSidebar: React.FC<ChatManagementSidebarProperties> = 
         });
       }
     }
-  }, [loadingChats, chats, title]);
+  }, [loadingChats, title]);
 
   return (
     <div className="flex w-[340px] shrink-0 flex-col border-r border-(--theme-border-color)">

--- a/src/features/chat/components/admin/chat-management-sidebar.tsx
+++ b/src/features/chat/components/admin/chat-management-sidebar.tsx
@@ -34,6 +34,30 @@ export const ChatManagementSidebar: React.FC<ChatManagementSidebarProperties> = 
   showClosed,
   onShowClosedChange,
 }) => {
+  const scrollContainerReference = React.useRef<HTMLDivElement>(null);
+
+  const handleScroll = (): void => {
+    if (scrollContainerReference.current) {
+      sessionStorage.setItem(
+        `chat-sidebar-scroll-${title}`,
+        String(scrollContainerReference.current.scrollTop),
+      );
+    }
+  };
+
+  React.useEffect(() => {
+    if (!loadingChats && scrollContainerReference.current) {
+      const saved = sessionStorage.getItem(`chat-sidebar-scroll-${title}`);
+      if (saved !== null && saved !== '') {
+        const container = scrollContainerReference.current;
+        const targetScroll = Number(saved);
+        requestAnimationFrame(() => {
+          container.scrollTop = targetScroll;
+        });
+      }
+    }
+  }, [loadingChats, chats, title]);
+
   return (
     <div className="flex w-[340px] shrink-0 flex-col border-r border-(--theme-border-color)">
       <div className="space-y-4 border-b border-(--theme-border-color) p-4">
@@ -73,7 +97,11 @@ export const ChatManagementSidebar: React.FC<ChatManagementSidebarProperties> = 
           </label>
         </div>
       </div>
-      <div className="flex-1 space-y-1 overflow-y-auto p-2">
+      <div
+        ref={scrollContainerReference}
+        onScroll={handleScroll}
+        className="flex-1 space-y-1 overflow-y-auto p-2"
+      >
         {loadingChats
           ? Array.from({ length: 5 }).map((_, index) => (
               <Skeleton key={index} className="h-20 w-full" />

--- a/src/features/chat/components/chat-view/message-list.tsx
+++ b/src/features/chat/components/chat-view/message-list.tsx
@@ -113,6 +113,7 @@ export const MessageList: React.FC<{
                       chatType={chatDetails.type}
                       hideReplyCount={hideReplyCount}
                       isThreadRoot={isThreadRoot}
+                      locale={locale}
                     />
                   </div>
                 );

--- a/src/features/chat/components/chat-view/message/index.tsx
+++ b/src/features/chat/components/chat-view/message/index.tsx
@@ -8,13 +8,11 @@ import { LocationMessage } from '@/features/chat/components/chat-view/message/lo
 import { SystemMessage } from '@/features/chat/components/chat-view/message/system-message';
 import { formatMessageContent } from '@/features/chat/components/chat-view/message/utils/format-message-content';
 import { useChatActions } from '@/features/chat/context/chat-actions-context';
-import { useFormatDate } from '@/features/chat/hooks/use-format-date';
+import { formatMessageTimeOnlyRaw } from '@/features/chat/hooks/use-format-date';
 import { MessageEventType, MessageType } from '@/lib/prisma/client';
 import type { Locale, StaticTranslationString } from '@/types/types';
-import { i18nConfig } from '@/types/types';
 import { cn } from '@/utils/tailwindcss-override';
 import { Check, Loader2, MessageSquare, UserCircle } from 'lucide-react';
-import { useCurrentLocale } from 'next-i18n-router/client';
 import React, { useRef, useState } from 'react';
 
 const DoubleCheck: React.FC<{ className?: string }> = ({ className }) => (
@@ -36,6 +34,7 @@ interface MessageProperties {
   chatType: string;
   hideReplyCount?: boolean;
   isThreadRoot?: boolean;
+  locale: Locale;
 }
 
 /**
@@ -52,15 +51,14 @@ export const MessageComponent: React.FC<MessageProperties> = ({
   chatType,
   hideReplyCount = false,
   isThreadRoot = false,
+  locale,
 }) => {
-  const locale = useCurrentLocale(i18nConfig) as Locale;
   const [isLongPressing, setIsLongPressing] = useState(false);
   const [swipeX, setSwipeX] = useState(0);
   const isPointerDown = useRef(false);
   const touchStartX = useRef(0);
   const touchStartY = useRef(0);
   const longPressTimerReference = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-  const { formatMessageTimeOnly } = useFormatDate();
   const renderedContent = formatMessageContent(message.messagePayload, locale);
   const {
     replyInThread,
@@ -298,7 +296,9 @@ export const MessageComponent: React.FC<MessageProperties> = ({
                 isCurrentUser ? 'text-white/80' : 'text-gray-400',
               )}
             >
-              <span className="font-body">{formatMessageTimeOnly(message.createdAt)}</span>
+              <span className="font-body">
+                {formatMessageTimeOnlyRaw(message.createdAt, locale)}
+              </span>
               {renderMessageStatus()}
             </div>
           </div>

--- a/src/features/chat/hooks/use-admin-chat-management.ts
+++ b/src/features/chat/hooks/use-admin-chat-management.ts
@@ -43,12 +43,18 @@ export const useAdminChatManagement = ({
     data: chats = [],
     isLoading: loadingChats,
     refetch: refetchChats,
-  } = trpc.admin.listSupportChats.useQuery({
-    type: chatType,
-    status: showClosed ? undefined : ChatStatus.OPEN,
-    search: debouncedSearch || undefined,
-    includeId: selectedChatId ?? undefined,
-  });
+  } = trpc.admin.listSupportChats.useQuery(
+    {
+      type: chatType,
+      status: showClosed ? undefined : ChatStatus.OPEN,
+      search: debouncedSearch || undefined,
+      includeId: selectedChatId ?? undefined,
+    },
+    {
+      // @ts-expect-error - feature of tanstack query used by trpc
+      keepPreviousData: true,
+    },
+  );
 
   const { data: messagesData, isLoading: loadingMessages } = trpc.admin.getChatMessages.useQuery(
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/features/chat/hooks/use-admin-chat-management.ts
+++ b/src/features/chat/hooks/use-admin-chat-management.ts
@@ -51,8 +51,7 @@ export const useAdminChatManagement = ({
       includeId: selectedChatId ?? undefined,
     },
     {
-      // @ts-expect-error - feature of tanstack query used by trpc
-      keepPreviousData: true,
+      placeholderData: (previousData) => previousData,
     },
   );
 

--- a/src/features/chat/hooks/use-format-date.ts
+++ b/src/features/chat/hooks/use-format-date.ts
@@ -13,7 +13,7 @@ const isToday = (date: Date): boolean => {
   );
 };
 
-const getDateFnsLocale = (localeString: string): typeof enUS => {
+export const getDateFnsLocale = (localeString: string): typeof enUS => {
   switch (localeString) {
     case 'de': {
       return de;
@@ -69,4 +69,13 @@ export const useFormatDate = (): {
   };
 
   return { formatMessageTime, formatMessageTimeOnly };
+};
+
+export const formatMessageTimeOnlyRaw = (timestamp: Date | string, locale: string): string => {
+  const dateFnsLocale = getDateFnsLocale(locale);
+  const date = timestamp instanceof Date ? timestamp : new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return format(date, 'HH:mm', { locale: dateFnsLocale });
 };

--- a/src/features/registration_process/components/management-view.tsx
+++ b/src/features/registration_process/components/management-view.tsx
@@ -23,8 +23,7 @@ const ManagementContent: React.FC = () => {
     },
     {
       refetchInterval: 5000,
-      // @ts-expect-error - feature of tanstack query used by trpc
-      keepPreviousData: true,
+      placeholderData: (previousData) => previousData,
     },
   );
 


### PR DESCRIPTION
### Description
This PR resolves the issue where selecting a chat in the **Emergency Alerts (Notfall Alarme)** and **Support Chat Management (Support-Chat-Verwaltung)** views within the Payload CMS admin panel triggers a scroll reset and loading skeleton flash in the left-hand sidebar.

### Changes
1. **Retain Sidebar Data During Switch:** Added `keepPreviousData: true` to the `trpc.admin.listSupportChats.useQuery` call. This keeps the previous chat list rendered while fetching data for the new selection instead of wiping the sidebar and showing loading skeletons (which causes DOM destruction and scroll reset).
2. **Scroll Position Preservation:** Configured scroll tracking in the sidebar component using a `React.useRef`. The container scrolls are saved to `sessionStorage` (keyed by panel title) on scroll and restored using `requestAnimationFrame` once the chats are loaded. This handles any full-view re-mounts/re-renders triggered by the Next.js router or Payload layout when query parameters change in the URL.