### PR TITLE
feat(payload-cms): add feature toggle to enable or disable checkHitobitoApprovals task

### DIFF
--- a/src/features/payload-cms/payload-cms/globals/app-feature-flags.ts
+++ b/src/features/payload-cms/payload-cms/globals/app-feature-flags.ts
@@ -6,6 +6,7 @@ import { AdminPanelDashboardGroups } from '@/features/payload-cms/payload-cms/ad
 import { flushPageCacheOnChangeGlobal } from '@/features/payload-cms/payload-cms/utils/flush-page-cache-on-change';
 import { setFeatureFlag } from '@/lib/db/redis';
 import {
+  FEATURE_FLAG_CHECK_HITOBITO_APPROVALS_ENABLED,
   FEATURE_FLAG_CREATE_CHATS_ENABLED,
   FEATURE_FLAG_HELPER_SHIFTS_ENABLED,
   FEATURE_FLAG_IMAGE_UPLOAD_ENABLED,
@@ -166,6 +167,31 @@ export const AppFeatureFlags: GlobalConfig = {
         afterChange: [
           async ({ value }): Promise<void> => {
             await setFeatureFlag(FEATURE_FLAG_RESERVATIONS_ENABLED, Boolean(value));
+          },
+        ],
+      },
+    },
+    {
+      name: 'checkHitobitoApprovalsEnabled',
+      label: {
+        en: 'Enable Check Hitobito Approvals Task',
+        de: 'Task "Check Hitobito Approvals" aktivieren',
+        fr: "Activer la tâche d'approbations Hitobito",
+      },
+      type: 'checkbox',
+      defaultValue: true,
+      admin: {
+        description:
+          'Toggles whether the scheduled task checks Hitobito approvals for pending registrations.',
+        components: {
+          Field:
+            '@/features/payload-cms/payload-cms/components/fields/feature-flag-toggle#FeatureFlagToggle',
+        },
+      },
+      hooks: {
+        afterChange: [
+          async ({ value }): Promise<void> => {
+            await setFeatureFlag(FEATURE_FLAG_CHECK_HITOBITO_APPROVALS_ENABLED, Boolean(value));
           },
         ],
       },

--- a/src/features/payload-cms/payload-cms/tasks/check-hitobito-approvals/index.ts
+++ b/src/features/payload-cms/payload-cms/tasks/check-hitobito-approvals/index.ts
@@ -3,6 +3,8 @@ import {
   DEFAULT_QUEUE,
 } from '@/features/payload-cms/payload-cms/tasks/cleanup-stale-jobs';
 import { getHitobito, HITOBITO_CONFIG } from '@/features/registration_process/hitobito-api';
+import { getFeatureFlag } from '@/lib/db/redis';
+import { FEATURE_FLAG_CHECK_HITOBITO_APPROVALS_ENABLED } from '@/lib/feature-flags';
 import type { PayloadRequest, TaskConfig } from 'payload';
 import { countRunnableOrActiveJobsForQueue } from 'payload';
 
@@ -43,6 +45,17 @@ export const checkHitobitoApprovalsTask: TaskConfig<'checkHitobitoApprovals'> = 
           queueable,
           req,
         }): Promise<{ shouldSchedule: boolean; input: Record<string, never> }> => {
+          const isEnabled = await getFeatureFlag(FEATURE_FLAG_CHECK_HITOBITO_APPROVALS_ENABLED);
+          if (!isEnabled) {
+            req.payload.logger.info(
+              'checkHitobitoApprovals task scheduler bypassed: task is disabled via feature flag.',
+            );
+            return {
+              shouldSchedule: false,
+              input: {},
+            };
+          }
+
           await cleanupStaleScheduledJobs(req, 'checkHitobitoApprovals', 15);
 
           const runnableOrActiveJobsForQueue = await countRunnableOrActiveJobsForQueue({
@@ -72,6 +85,13 @@ export const checkHitobitoApprovalsTask: TaskConfig<'checkHitobitoApprovals'> = 
   }): Promise<{ output: Record<string, unknown> }> => {
     const { payload } = req;
     const { logger } = payload;
+
+    const isEnabled = await getFeatureFlag(FEATURE_FLAG_CHECK_HITOBITO_APPROVALS_ENABLED);
+    if (!isEnabled) {
+      logger.info('checkHitobitoApprovals task bypassed: task is disabled via feature flag.');
+      return { output: {} };
+    }
+
     const { helperGroupId: groupId } = HITOBITO_CONFIG;
 
     if (groupId === undefined || groupId === '') {

--- a/src/features/payload-cms/payload-types.ts
+++ b/src/features/payload-cms/payload-types.ts
@@ -6474,6 +6474,10 @@ export interface AppFeatureFlag {
    * Toggles visibility of the Reservations menu item in the app.
    */
   reservationsEnabled?: boolean | null;
+  /**
+   * Toggles whether the scheduled task checks Hitobito approvals for pending registrations.
+   */
+  checkHitobitoApprovalsEnabled?: boolean | null;
   updatedAt?: string | null;
   createdAt?: string | null;
 }
@@ -6801,6 +6805,7 @@ export interface AppFeatureFlagsSelect<T extends boolean = true> {
   helperShiftsEnabled?: T;
   imageUploadEnabled?: T;
   reservationsEnabled?: T;
+  checkHitobitoApprovalsEnabled?: T;
   updatedAt?: T;
   createdAt?: T;
   globalType?: T;

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -4,6 +4,7 @@ export const FEATURE_FLAG_HELPER_SHIFTS_ENABLED = 'helper_shifts_enabled';
 export const FEATURE_FLAG_IMAGE_UPLOAD_ENABLED = 'image_upload_enabled';
 export const FEATURE_FLAG_RESERVATIONS_ENABLED = 'reservations_enabled';
 export const FEATURE_HIDE_HOF_AND_QUARTIER = 'hide_hof_and_quartier';
+export const FEATURE_FLAG_CHECK_HITOBITO_APPROVALS_ENABLED = 'check_hitobito_approvals_enabled';
 
 export const FEATURE_FLAG_DEFAULTS: Record<string, boolean> = {
   [FEATURE_FLAG_SEND_MESSAGES]: true,
@@ -12,4 +13,5 @@ export const FEATURE_FLAG_DEFAULTS: Record<string, boolean> = {
   [FEATURE_FLAG_IMAGE_UPLOAD_ENABLED]: true,
   [FEATURE_FLAG_RESERVATIONS_ENABLED]: true,
   [FEATURE_HIDE_HOF_AND_QUARTIER]: false,
+  [FEATURE_FLAG_CHECK_HITOBITO_APPROVALS_ENABLED]: true,
 };


### PR DESCRIPTION
This PR adds a feature toggle for the 'checkHitobitoApprovals' task, allowing administrators to enable or disable it using the 'App Feature Flags' global page inside the Payload CMS admin interface.