### PR TITLE
feat(payload): display Name and Email for users in relationships #1237

### DIFF
--- a/src/features/payload-cms/payload-cms/collections/user-collection.ts
+++ b/src/features/payload-cms/payload-cms/collections/user-collection.ts
@@ -72,7 +72,7 @@ export const UserCollection: CollectionConfig = {
   admin: {
     description:
       'Represents a user. Data gets automatically synced from Hitobito whenever the user logs in. Users can also be created manually or imported via CSV.',
-    useAsTitle: 'email',
+    useAsTitle: 'displayName',
     group: AdminPanelDashboardGroups.InternalCollections,
     groupBy: true,
     /** this is broken with our localized versions */
@@ -91,6 +91,38 @@ export const UserCollection: CollectionConfig = {
     ],
   },
   fields: [
+    {
+      name: 'displayName',
+      type: 'text',
+      virtual: true,
+      admin: {
+        hidden: true,
+      },
+      hooks: {
+        afterRead: [
+          ({ data }): string => {
+            if (!data) return '';
+            const email = (data as User).email;
+            const fullName = (data as User).fullName;
+            const nickname = (data as User).nickname;
+
+            const nameParts: string[] = [];
+            if (typeof fullName === 'string' && fullName !== '') {
+              nameParts.push(fullName);
+            }
+            if (typeof nickname === 'string' && nickname !== '') {
+              nameParts.push(`v/o ${nickname}`);
+            }
+
+            const nameString = nameParts.join(' ');
+            if (typeof email === 'string' && email !== '') {
+              return nameString === '' ? email : `${nameString} (${email})`;
+            }
+            return nameString === '' ? 'Unnamed User' : nameString;
+          },
+        ],
+      },
+    },
     {
       name: 'cevi_db_uuid',
       label: 'UserID inside CeviDB',

--- a/src/features/payload-cms/payload-cms/collections/user-collection.ts
+++ b/src/features/payload-cms/payload-cms/collections/user-collection.ts
@@ -100,8 +100,14 @@ export const UserCollection: CollectionConfig = {
       },
       hooks: {
         afterRead: [
-          ({ data }): string => {
-            if (!data) return '';
+          ({ data }): string | undefined => {
+            if (!data) return undefined;
+
+            // Prevent silent fallback when document is partially selected
+            if (!('email' in data) && !('fullName' in data) && !('nickname' in data)) {
+              return undefined;
+            }
+
             const email = (data as User).email;
             const fullName = (data as User).fullName;
             const nickname = (data as User).nickname;

--- a/src/features/payload-cms/payload-types.ts
+++ b/src/features/payload-cms/payload-types.ts
@@ -495,6 +495,7 @@ export interface LocalizedPublishingStatus {
  */
 export interface User {
   id: string;
+  displayName?: string | null;
   /**
    * The ID of the user in the CeviDB. Set automatically when the user logs in via Hitobito. Leave empty for manually created users.
    */
@@ -5468,6 +5469,7 @@ export interface DocumentsSelect<T extends boolean = true> {
  * via the `definition` "users_select".
  */
 export interface UsersSelect<T extends boolean = true> {
+  displayName?: T;
   cevi_db_uuid?: T;
   adminPanelAccess?: T;
   email?: T;


### PR DESCRIPTION
This PR introduces a virtual/computed field `displayName` in the `users` collection which formats the user as `FullName v/o Nickname (email)` dynamically, and sets it as the `useAsTitle` field. This ensures that organizers and other users in CMS relationship fields are visually identified by Name + Mail rather than just their Email address, addressing issue #1237.