### PR TITLE
fix(onboarding): handle native push permission in onboarding flow

### DIFF
--- a/src/features/native-push/api/native-push-router.ts
+++ b/src/features/native-push/api/native-push-router.ts
@@ -15,7 +15,12 @@ export const nativePushRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const tokenPreview = `${input.token.slice(0, 8)}…`;
-      console.log('[NativePush:API] registerDevice: platform =', input.platform, '| token =', tokenPreview);
+      console.log(
+        '[NativePush:API] registerDevice: platform =',
+        input.platform,
+        '| token =',
+        tokenPreview,
+      );
 
       const payload = await getPayload({ config });
       const payloadUser = await getPayloadUserFromNextAuthUser(payload, ctx.user);
@@ -25,7 +30,11 @@ export const nativePushRouter = createTRPCRouter({
         throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
       }
 
-      console.log('[NativePush:API] registerDevice: user =', payloadUser.id, '| deduplicating existing token');
+      console.log(
+        '[NativePush:API] registerDevice: user =',
+        payloadUser.id,
+        '| deduplicating existing token',
+      );
 
       // Delete any existing subscriptions with the same token globally to ensure uniqueness
       const deleted = await payload.delete({
@@ -35,7 +44,11 @@ export const nativePushRouter = createTRPCRouter({
         },
       });
       if (deleted.docs.length > 0) {
-        console.log('[NativePush:API] registerDevice: removed', deleted.docs.length, 'existing record(s) for this token');
+        console.log(
+          '[NativePush:API] registerDevice: removed',
+          deleted.docs.length,
+          'existing record(s) for this token',
+        );
       }
 
       try {
@@ -47,7 +60,10 @@ export const nativePushRouter = createTRPCRouter({
             user: payloadUser.id,
           },
         });
-        console.log('[NativePush:API] registerDevice: success — token registered for user', payloadUser.id);
+        console.log(
+          '[NativePush:API] registerDevice: success — token registered for user',
+          payloadUser.id,
+        );
       } catch (error: unknown) {
         // Under concurrent requests, the delete+create pattern is non-atomic.
         // If a duplicate key error occurs, we assume the token is already registered.
@@ -70,7 +86,12 @@ export const nativePushRouter = createTRPCRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const tokenPreview = `${input.token.slice(0, 8)}…`;
-      console.log('[NativePush:API] unregisterDevice: platform =', input.platform, '| token =', tokenPreview);
+      console.log(
+        '[NativePush:API] unregisterDevice: platform =',
+        input.platform,
+        '| token =',
+        tokenPreview,
+      );
 
       const payload = await getPayload({ config });
       const payloadUser = await getPayloadUserFromNextAuthUser(payload, ctx.user);
@@ -91,7 +112,12 @@ export const nativePushRouter = createTRPCRouter({
         },
       });
 
-      console.log('[NativePush:API] unregisterDevice: removed', deleted.docs.length, 'record(s) for user', payloadUser.id);
+      console.log(
+        '[NativePush:API] unregisterDevice: removed',
+        deleted.docs.length,
+        'record(s) for user',
+        payloadUser.id,
+      );
       return { success: true };
     }),
 });

--- a/src/features/native-push/api/native-push-router.ts
+++ b/src/features/native-push/api/native-push-router.ts
@@ -14,20 +14,29 @@ export const nativePushRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
+      const tokenPreview = `${input.token.slice(0, 8)}…`;
+      console.log('[NativePush:API] registerDevice: platform =', input.platform, '| token =', tokenPreview);
+
       const payload = await getPayload({ config });
       const payloadUser = await getPayloadUserFromNextAuthUser(payload, ctx.user);
 
       if (!payloadUser) {
+        console.warn('[NativePush:API] registerDevice: user not found for token', tokenPreview);
         throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
       }
 
+      console.log('[NativePush:API] registerDevice: user =', payloadUser.id, '| deduplicating existing token');
+
       // Delete any existing subscriptions with the same token globally to ensure uniqueness
-      await payload.delete({
+      const deleted = await payload.delete({
         collection: 'push-notification-subscriptions',
         where: {
           token: { equals: input.token },
         },
       });
+      if (deleted.docs.length > 0) {
+        console.log('[NativePush:API] registerDevice: removed', deleted.docs.length, 'existing record(s) for this token');
+      }
 
       try {
         await payload.create({
@@ -38,12 +47,13 @@ export const nativePushRouter = createTRPCRouter({
             user: payloadUser.id,
           },
         });
+        console.log('[NativePush:API] registerDevice: success — token registered for user', payloadUser.id);
       } catch (error: unknown) {
         // Under concurrent requests, the delete+create pattern is non-atomic.
         // If a duplicate key error occurs, we assume the token is already registered.
         const message = error instanceof Error ? error.message : String(error);
         console.warn(
-          'Failed to create push notification subscription (possibly concurrent duplicate):',
+          '[NativePush:API] registerDevice: create failed (possibly concurrent duplicate):',
           message,
         );
       }
@@ -59,14 +69,18 @@ export const nativePushRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
+      const tokenPreview = `${input.token.slice(0, 8)}…`;
+      console.log('[NativePush:API] unregisterDevice: platform =', input.platform, '| token =', tokenPreview);
+
       const payload = await getPayload({ config });
       const payloadUser = await getPayloadUserFromNextAuthUser(payload, ctx.user);
 
       if (!payloadUser) {
+        console.warn('[NativePush:API] unregisterDevice: user not found for token', tokenPreview);
         throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
       }
 
-      await payload.delete({
+      const deleted = await payload.delete({
         collection: 'push-notification-subscriptions',
         where: {
           and: [
@@ -77,6 +91,7 @@ export const nativePushRouter = createTRPCRouter({
         },
       });
 
+      console.log('[NativePush:API] unregisterDevice: removed', deleted.docs.length, 'record(s) for user', payloadUser.id);
       return { success: true };
     }),
 });

--- a/src/features/onboarding/components/native-push-subscription-manager.tsx
+++ b/src/features/onboarding/components/native-push-subscription-manager.tsx
@@ -103,7 +103,7 @@ export const NativePushSubscriptionManager: React.FC<{
     return (
       <div className="flex flex-col items-center gap-4">
         <div className="flex items-center justify-center rounded-lg bg-yellow-50 p-3 text-yellow-800">
-          <span className="text-balance text-sm font-semibold">{deniedText[locale]}</span>
+          <span className="text-sm font-semibold text-balance">{deniedText[locale]}</span>
         </div>
         <button
           className="font-heading flex cursor-pointer items-center justify-center gap-2 rounded-[8px] bg-red-700 px-8 py-3 text-center text-lg leading-normal font-bold text-red-100 duration-100 hover:bg-red-800"

--- a/src/features/onboarding/components/native-push-subscription-manager.tsx
+++ b/src/features/onboarding/components/native-push-subscription-manager.tsx
@@ -51,6 +51,7 @@ export const NativePushSubscriptionManager: React.FC<{
   const advance = useCallback((): void => {
     if (!hasAdvancedRef.current) {
       hasAdvancedRef.current = true;
+      setIsRequesting(false);
       callbackRef.current();
     }
   }, []);

--- a/src/features/onboarding/components/native-push-subscription-manager.tsx
+++ b/src/features/onboarding/components/native-push-subscription-manager.tsx
@@ -33,6 +33,10 @@ const skipButtonText: StaticTranslationString = {
   fr: "Passer pour l'instant",
 };
 
+const handleOpenSettings = (): void => {
+  globalThis.AppWebViewNativePush?.openSettings();
+};
+
 interface NativePushEventDetail {
   type?: string;
   payload?: Record<string, unknown>;
@@ -44,15 +48,18 @@ export const NativePushSubscriptionManager: React.FC<{
 }> = ({ callback, locale }) => {
   const [isRequesting, setIsRequesting] = useState(false);
   const [isDenied, setIsDenied] = useState(false);
-  const callbackRef = useRef(callback);
-  callbackRef.current = callback;
-  const hasAdvancedRef = useRef(false);
+  const callbackReference = useRef(callback);
+  const hasAdvancedReference = useRef(false);
+
+  useEffect(() => {
+    callbackReference.current = callback;
+  }, [callback]);
 
   const advance = useCallback((): void => {
-    if (!hasAdvancedRef.current) {
-      hasAdvancedRef.current = true;
+    if (!hasAdvancedReference.current) {
+      hasAdvancedReference.current = true;
       setIsRequesting(false);
-      callbackRef.current();
+      callbackReference.current();
     }
   }, []);
 
@@ -77,10 +84,8 @@ export const NativePushSubscriptionManager: React.FC<{
           // not-determined or unknown — permission dialog dismissed without granting
           setIsRequesting(false);
         }
-      } else if (type === 'native-push-token') {
-        if (typeof payload['token'] === 'string') {
-          advance();
-        }
+      } else if (type === 'native-push-token' && typeof payload['token'] === 'string') {
+        advance();
       }
     };
 
@@ -93,10 +98,6 @@ export const NativePushSubscriptionManager: React.FC<{
   const handleEnable = (): void => {
     setIsRequesting(true);
     globalThis.AppWebViewNativePush?.requestPermission();
-  };
-
-  const handleOpenSettings = (): void => {
-    globalThis.AppWebViewNativePush?.openSettings();
   };
 
   if (isDenied) {

--- a/src/features/onboarding/components/native-push-subscription-manager.tsx
+++ b/src/features/onboarding/components/native-push-subscription-manager.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import type { StaticTranslationString } from '@/types/types';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+const descriptionText: StaticTranslationString = {
+  en: 'You are not subscribed to push notifications.',
+  de: 'Du bist nicht für Push-Benachrichtigungen angemeldet.',
+  fr: "Vous n'êtes pas abonné aux notifications push.",
+};
+
+const enableButtonText: StaticTranslationString = {
+  en: 'Enable Notifications',
+  de: 'Benachrichtigungen aktivieren',
+  fr: 'Activer les notifications',
+};
+
+const deniedText: StaticTranslationString = {
+  en: 'Push notifications are blocked. Enable them in your device settings.',
+  de: 'Push-Benachrichtigungen sind gesperrt. Bitte in den Geräteeinstellungen aktivieren.',
+  fr: 'Les notifications push sont bloquées. Activez-les dans les paramètres de votre appareil.',
+};
+
+const openSettingsButtonText: StaticTranslationString = {
+  en: 'Open Settings',
+  de: 'Einstellungen öffnen',
+  fr: 'Ouvrir les paramètres',
+};
+
+const skipButtonText: StaticTranslationString = {
+  en: 'Skip for now',
+  de: 'Überspringen',
+  fr: "Passer pour l'instant",
+};
+
+interface NativePushEventDetail {
+  type?: string;
+  payload?: Record<string, unknown>;
+}
+
+export const NativePushSubscriptionManager: React.FC<{
+  callback: () => void;
+  locale: 'de' | 'fr' | 'en';
+}> = ({ callback, locale }) => {
+  const [isRequesting, setIsRequesting] = useState(false);
+  const [isDenied, setIsDenied] = useState(false);
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+  const hasAdvancedRef = useRef(false);
+
+  const advance = useCallback((): void => {
+    if (!hasAdvancedRef.current) {
+      hasAdvancedRef.current = true;
+      callbackRef.current();
+    }
+  }, []);
+
+  useEffect(() => {
+    // Check current status on mount — auto-advances if already authorized
+    globalThis.AppWebViewNativePush?.getStatus();
+
+    const handleEvent = (event: Event): void => {
+      const customEvent = event as CustomEvent<NativePushEventDetail | null>;
+      const detail = customEvent.detail ?? {};
+      const type = detail.type;
+      const payload = detail.payload ?? {};
+
+      if (type === 'native-push-status') {
+        const label = payload['authorizationLabel'];
+        if (label === 'authorized' || label === 'provisional') {
+          advance();
+        } else if (label === 'denied') {
+          setIsRequesting(false);
+          setIsDenied(true);
+        } else {
+          // not-determined or unknown — permission dialog dismissed without granting
+          setIsRequesting(false);
+        }
+      } else if (type === 'native-push-token') {
+        if (typeof payload['token'] === 'string') {
+          advance();
+        }
+      }
+    };
+
+    globalThis.addEventListener('app-webview-native-push-event', handleEvent);
+    return (): void => {
+      globalThis.removeEventListener('app-webview-native-push-event', handleEvent);
+    };
+  }, [advance]);
+
+  const handleEnable = (): void => {
+    setIsRequesting(true);
+    globalThis.AppWebViewNativePush?.requestPermission();
+  };
+
+  const handleOpenSettings = (): void => {
+    globalThis.AppWebViewNativePush?.openSettings();
+  };
+
+  if (isDenied) {
+    return (
+      <div className="flex flex-col items-center gap-4">
+        <div className="flex items-center justify-center rounded-lg bg-yellow-50 p-3 text-yellow-800">
+          <span className="text-balance text-sm font-semibold">{deniedText[locale]}</span>
+        </div>
+        <button
+          className="font-heading flex cursor-pointer items-center justify-center gap-2 rounded-[8px] bg-red-700 px-8 py-3 text-center text-lg leading-normal font-bold text-red-100 duration-100 hover:bg-red-800"
+          onClick={handleOpenSettings}
+        >
+          {openSettingsButtonText[locale]}
+        </button>
+        <button
+          className="cursor-pointer font-semibold text-gray-400 hover:text-gray-600"
+          onClick={advance}
+        >
+          {skipButtonText[locale]}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-0 flex flex-col items-center">
+      <p className="mb-4 text-balance text-gray-700">{descriptionText[locale]}</p>
+      <button
+        className="font-heading flex cursor-pointer items-center justify-center gap-2 rounded-[8px] bg-red-700 px-8 py-3 text-center text-lg leading-normal font-bold text-red-100 duration-100 hover:bg-red-800 disabled:cursor-not-allowed disabled:opacity-50"
+        onClick={handleEnable}
+        disabled={isRequesting}
+      >
+        {isRequesting && (
+          <div className="h-5 w-5 shrink-0 animate-spin rounded-full border-2 border-white border-t-transparent" />
+        )}
+        {enableButtonText[locale]}
+      </button>
+    </div>
+  );
+};

--- a/src/features/onboarding/components/push-notification-subscription-manager.tsx
+++ b/src/features/onboarding/components/push-notification-subscription-manager.tsx
@@ -17,7 +17,7 @@ export const PushNotificationSubscriptionManager: React.FC<{
   callback: () => void;
   locale: 'de' | 'fr' | 'en';
 }> = ({ callback, locale }) => {
-  const [isNative, setIsNative] = useState(false);
+  const [isNative, setIsNative] = useState<boolean | null>(null);
 
   useEffect(() => {
     setIsNative(isNativeAppWebView());
@@ -27,6 +27,8 @@ export const PushNotificationSubscriptionManager: React.FC<{
   // The result is intentionally unused in native mode.
   const { isSupported, isSubscribed, isLoading, errorMessage, toggleSubscription } =
     usePushNotificationState({ registrationSource: '/entrypoint', locale });
+
+  if (isNative === null) return null;
 
   if (isNative) {
     return <NativePushSubscriptionManager callback={callback} locale={locale} />;

--- a/src/features/onboarding/components/push-notification-subscription-manager.tsx
+++ b/src/features/onboarding/components/push-notification-subscription-manager.tsx
@@ -1,19 +1,36 @@
+'use client';
+
+import { NativePushSubscriptionManager } from '@/features/onboarding/components/native-push-subscription-manager';
 import { PushNotificationActions } from '@/features/onboarding/components/push-notification-actions';
 import { PushNotificationNotSupported } from '@/features/onboarding/components/push-notification-not-supported';
 import { usePushNotificationState } from '@/hooks/use-push-notification-state';
+import { isNativeAppWebView } from '@/utils/standalone-check';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 /**
  * PushNotificationManager is a React component that manages push notifications.
- * @constructor
+ * Routes to native push handling when running inside the KonektaApp WebView,
+ * and falls back to Web Push for browser-based installs.
  */
 export const PushNotificationSubscriptionManager: React.FC<{
   callback: () => void;
   locale: 'de' | 'fr' | 'en';
 }> = ({ callback, locale }) => {
+  const [isNative, setIsNative] = useState(false);
+
+  useEffect(() => {
+    setIsNative(isNativeAppWebView());
+  }, []);
+
+  // Always call the web push hook so hook call order is stable across renders.
+  // The result is intentionally unused in native mode.
   const { isSupported, isSubscribed, isLoading, errorMessage, toggleSubscription } =
     usePushNotificationState({ registrationSource: '/entrypoint', locale });
+
+  if (isNative) {
+    return <NativePushSubscriptionManager callback={callback} locale={locale} />;
+  }
 
   if (!isSupported) {
     return <PushNotificationNotSupported locale={locale} onSkip={callback} />;

--- a/src/features/onboarding/components/push-notification-subscription-manager.tsx
+++ b/src/features/onboarding/components/push-notification-subscription-manager.tsx
@@ -6,7 +6,11 @@ import { PushNotificationNotSupported } from '@/features/onboarding/components/p
 import { usePushNotificationState } from '@/hooks/use-push-notification-state';
 import { isNativeAppWebView } from '@/utils/standalone-check';
 
-import React, { useEffect, useState } from 'react';
+import React, { useSyncExternalStore } from 'react';
+
+const noopUnsubscribe = (): undefined => undefined;
+const subscribeToNothing = (): (() => void) => noopUnsubscribe;
+const getServerIsNative = (): boolean => false;
 
 /**
  * PushNotificationManager is a React component that manages push notifications.
@@ -17,18 +21,12 @@ export const PushNotificationSubscriptionManager: React.FC<{
   callback: () => void;
   locale: 'de' | 'fr' | 'en';
 }> = ({ callback, locale }) => {
-  const [isNative, setIsNative] = useState<boolean | null>(null);
-
-  useEffect(() => {
-    setIsNative(isNativeAppWebView());
-  }, []);
+  const isNative = useSyncExternalStore(subscribeToNothing, isNativeAppWebView, getServerIsNative);
 
   // Always call the web push hook so hook call order is stable across renders.
   // The result is intentionally unused in native mode.
   const { isSupported, isSubscribed, isLoading, errorMessage, toggleSubscription } =
     usePushNotificationState({ registrationSource: '/entrypoint', locale });
-
-  if (isNative === null) return null;
 
   if (isNative) {
     return <NativePushSubscriptionManager callback={callback} locale={locale} />;

--- a/src/hooks/use-native-push.ts
+++ b/src/hooks/use-native-push.ts
@@ -39,7 +39,12 @@ export function useNativePush(): {
     // Maintain backward compatibility for older app versions that don't inject the bridge
     const isBridgeReady = globalThis.AppWebViewNativePush !== undefined;
 
-    console.log('[NativePush:PWA] hook mounted: isNative =', isNative, '| bridgeReady =', isBridgeReady);
+    console.log(
+      '[NativePush:PWA] hook mounted: isNative =',
+      isNative,
+      '| bridgeReady =',
+      isBridgeReady,
+    );
 
     const timeoutId = setTimeout(() => {
       setIsNativeApp(isNative && isBridgeReady);
@@ -77,7 +82,12 @@ export function useNativePush(): {
               payload['hasToken'] === undefined
                 ? typeof tokenValue === 'string' && tokenValue !== ''
                 : payload['hasToken'] === true || payload['hasToken'] === 'true';
-            console.log('[NativePush:PWA] status update: authLabel =', statusValue, '| hasToken =', hasTokenValue);
+            console.log(
+              '[NativePush:PWA] status update: authLabel =',
+              statusValue,
+              '| hasToken =',
+              hasTokenValue,
+            );
             setStatus(statusValue as NativePushStatus);
             setHasToken(hasTokenValue);
           }
@@ -86,22 +96,29 @@ export function useNativePush(): {
         case 'native-push-token': {
           const token = payload['token'];
           const platform = payload['platform'];
-          console.log('[NativePush:PWA] token received: platform =', platform, '| token =', typeof token === 'string' ? `${token.slice(0, 8)}…` : 'missing');
+          console.log(
+            '[NativePush:PWA] token received: platform =',
+            platform,
+            '| token =',
+            typeof token === 'string' ? `${token.slice(0, 8)}…` : 'missing',
+          );
           if (typeof token === 'string' && typeof platform === 'string') {
             console.log('[NativePush:PWA] calling registerDevice: platform =', platform);
             registerDevice({
               token,
               platform: platform as 'ios' | 'android',
-            }).then(() => {
-              console.log('[NativePush:PWA] registerDevice: success');
-            }).catch((error: unknown) => {
-              console.error('[NativePush:PWA] registerDevice: failed', error);
-              if (error instanceof Error) {
-                void import('posthog-js').then(({ default: ph }) => {
-                  ph.capture('native_push_register_error', { error: error.message });
-                });
-              }
-            });
+            })
+              .then(() => {
+                console.log('[NativePush:PWA] registerDevice: success');
+              })
+              .catch((error: unknown) => {
+                console.error('[NativePush:PWA] registerDevice: failed', error);
+                if (error instanceof Error) {
+                  void import('posthog-js').then(({ default: ph }) => {
+                    ph.capture('native_push_register_error', { error: error.message });
+                  });
+                }
+              });
             setStatus('granted');
             setHasToken(true);
           }
@@ -110,17 +127,24 @@ export function useNativePush(): {
         case 'native-push-token-deleted': {
           const token = payload['token'];
           const platform = payload['platform'];
-          console.log('[NativePush:PWA] token deleted: platform =', platform, '| token =', typeof token === 'string' ? `${token.slice(0, 8)}…` : 'missing');
+          console.log(
+            '[NativePush:PWA] token deleted: platform =',
+            platform,
+            '| token =',
+            typeof token === 'string' ? `${token.slice(0, 8)}…` : 'missing',
+          );
           if (typeof token === 'string' && typeof platform === 'string') {
             console.log('[NativePush:PWA] calling unregisterDevice: platform =', platform);
             unregisterDevice({
               token,
               platform: platform as 'ios' | 'android',
-            }).then(() => {
-              console.log('[NativePush:PWA] unregisterDevice: success');
-            }).catch((error: unknown) => {
-              console.error('[NativePush:PWA] unregisterDevice: failed', error);
-            });
+            })
+              .then(() => {
+                console.log('[NativePush:PWA] unregisterDevice: success');
+              })
+              .catch((error: unknown) => {
+                console.error('[NativePush:PWA] unregisterDevice: failed', error);
+              });
           }
           setHasToken(false);
           setStatus('prompt');
@@ -131,10 +155,15 @@ export function useNativePush(): {
             // Only allow relative (same-origin) paths to prevent open redirects
             const url = payload['url'];
             const isRelative = url.startsWith('/') && !url.startsWith('//');
-            console.log('[NativePush:PWA] notification opened, navigating to:', isRelative ? url : '/app/dashboard');
+            console.log(
+              '[NativePush:PWA] notification opened, navigating to:',
+              isRelative ? url : '/app/dashboard',
+            );
             router.push(isRelative ? url : '/app/dashboard');
           } else {
-            console.log('[NativePush:PWA] notification opened (no url), navigating to /app/dashboard');
+            console.log(
+              '[NativePush:PWA] notification opened (no url), navigating to /app/dashboard',
+            );
             router.push('/app/dashboard');
           }
           break;

--- a/src/hooks/use-native-push.ts
+++ b/src/hooks/use-native-push.ts
@@ -39,6 +39,8 @@ export function useNativePush(): {
     // Maintain backward compatibility for older app versions that don't inject the bridge
     const isBridgeReady = globalThis.AppWebViewNativePush !== undefined;
 
+    console.log('[NativePush:PWA] hook mounted: isNative =', isNative, '| bridgeReady =', isBridgeReady);
+
     const timeoutId = setTimeout(() => {
       setIsNativeApp(isNative && isBridgeReady);
     }, 0);
@@ -58,8 +60,11 @@ export function useNativePush(): {
       const type = detail.type;
       const payload = detail.payload ?? {};
 
+      console.log('[NativePush:PWA] event received:', type);
+
       switch (type) {
         case 'native-push-ready': {
+          console.log('[NativePush:PWA] bridge ready, requesting status');
           setIsNativeApp(true);
           globalThis.AppWebViewNativePush?.getStatus();
           break;
@@ -67,23 +72,30 @@ export function useNativePush(): {
         case 'native-push-status': {
           const statusValue = payload['authorizationLabel'] ?? payload['status'];
           if (typeof statusValue === 'string') {
-            setStatus(statusValue as NativePushStatus);
             const tokenValue = payload['token'];
             const hasTokenValue =
               payload['hasToken'] === undefined
                 ? typeof tokenValue === 'string' && tokenValue !== ''
                 : payload['hasToken'] === true || payload['hasToken'] === 'true';
+            console.log('[NativePush:PWA] status update: authLabel =', statusValue, '| hasToken =', hasTokenValue);
+            setStatus(statusValue as NativePushStatus);
             setHasToken(hasTokenValue);
           }
           break;
         }
         case 'native-push-token': {
-          if (typeof payload['token'] === 'string' && typeof payload['platform'] === 'string') {
+          const token = payload['token'];
+          const platform = payload['platform'];
+          console.log('[NativePush:PWA] token received: platform =', platform, '| token =', typeof token === 'string' ? `${token.slice(0, 8)}…` : 'missing');
+          if (typeof token === 'string' && typeof platform === 'string') {
+            console.log('[NativePush:PWA] calling registerDevice: platform =', platform);
             registerDevice({
-              token: payload['token'],
-              platform: payload['platform'] as 'ios' | 'android',
+              token,
+              platform: platform as 'ios' | 'android',
+            }).then(() => {
+              console.log('[NativePush:PWA] registerDevice: success');
             }).catch((error: unknown) => {
-              console.error('Failed to register native device token', error);
+              console.error('[NativePush:PWA] registerDevice: failed', error);
               if (error instanceof Error) {
                 void import('posthog-js').then(({ default: ph }) => {
                   ph.capture('native_push_register_error', { error: error.message });
@@ -96,12 +108,18 @@ export function useNativePush(): {
           break;
         }
         case 'native-push-token-deleted': {
-          if (typeof payload['token'] === 'string' && typeof payload['platform'] === 'string') {
+          const token = payload['token'];
+          const platform = payload['platform'];
+          console.log('[NativePush:PWA] token deleted: platform =', platform, '| token =', typeof token === 'string' ? `${token.slice(0, 8)}…` : 'missing');
+          if (typeof token === 'string' && typeof platform === 'string') {
+            console.log('[NativePush:PWA] calling unregisterDevice: platform =', platform);
             unregisterDevice({
-              token: payload['token'],
-              platform: payload['platform'] as 'ios' | 'android',
+              token,
+              platform: platform as 'ios' | 'android',
+            }).then(() => {
+              console.log('[NativePush:PWA] unregisterDevice: success');
             }).catch((error: unknown) => {
-              console.error('Failed to unregister native device token', error);
+              console.error('[NativePush:PWA] unregisterDevice: failed', error);
             });
           }
           setHasToken(false);
@@ -113,14 +131,16 @@ export function useNativePush(): {
             // Only allow relative (same-origin) paths to prevent open redirects
             const url = payload['url'];
             const isRelative = url.startsWith('/') && !url.startsWith('//');
+            console.log('[NativePush:PWA] notification opened, navigating to:', isRelative ? url : '/app/dashboard');
             router.push(isRelative ? url : '/app/dashboard');
           } else {
+            console.log('[NativePush:PWA] notification opened (no url), navigating to /app/dashboard');
             router.push('/app/dashboard');
           }
           break;
         }
         case 'native-push-error': {
-          console.error('Native push error:', payload['error']);
+          console.error('[NativePush:PWA] bridge error:', payload['error']);
           void import('posthog-js').then(({ default: ph }) => {
             ph.capture('native_push_error', { error: payload['error'] });
           });
@@ -132,6 +152,7 @@ export function useNativePush(): {
     globalThis.addEventListener('app-webview-native-push-event', handleNativeEvent);
 
     // Initial status check
+    console.log('[NativePush:PWA] requesting initial status');
     globalThis.AppWebViewNativePush?.getStatus();
 
     return (): void => {
@@ -142,18 +163,21 @@ export function useNativePush(): {
 
   const requestPermission = (): void => {
     if (isNativeApp) {
+      console.log('[NativePush:PWA] requestPermission called');
       globalThis.AppWebViewNativePush?.requestPermission();
     }
   };
 
   const deleteToken = (): void => {
     if (isNativeApp) {
+      console.log('[NativePush:PWA] deleteToken called');
       globalThis.AppWebViewNativePush?.deleteToken();
     }
   };
 
   const openSettings = (): void => {
     if (isNativeApp) {
+      console.log('[NativePush:PWA] openSettings called');
       globalThis.AppWebViewNativePush?.openSettings();
     }
   };


### PR DESCRIPTION
## Summary

- Adds `NativePushSubscriptionManager`: a bridge-event-driven onboarding component that requests native push permission without needing TRPC
- Updates `PushNotificationSubscriptionManager` to detect `isNativeAppWebView()` and render the native component instead of the web push UI

**Root cause of cevi/konekta-app#14:** The onboarding push step used `usePushNotificationState` (Web Push only). In the KonektaApp WebView, `PushManager` is unavailable → `isPushSupported()` returns `false` → step showed "not supported" → user skipped → native push permission was never requested → toggle appeared permanently off in settings.

**How the fix works:**
- On native app: shows "Enable Notifications" button that calls `window.AppWebViewNativePush.requestPermission()`
- Listens for `app-webview-native-push-event` bridge events to detect the result
- Auto-advances if permissions are already granted (returning user)
- Shows spinner while the OS permission dialog is open
- Shows "Open Settings" + skip option when denied
- Token registration with the backend continues via `NativePushProvider` in the main app shell once onboarding completes — no TRPC needed in this component

Related: cevi/konekta-app#14

## Test plan

- [ ] Fresh install on iOS: onboarding push step shows "Enable Notifications" → tapping triggers iOS permission dialog → granting advances the step
- [ ] Fresh install on Android: same flow with Android permission dialog
- [ ] Returning user with permissions already granted: push step auto-advances without showing dialog
- [ ] User denies: "blocked" state shown with "Open Settings" and skip options
- [ ] Browser (non-native): existing web push flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)