### PR TITLE
fix(onboarding): fix native push permission flow on iOS

### DIFF
--- a/src/features/onboarding/hooks/use-onboarding.ts
+++ b/src/features/onboarding/hooks/use-onboarding.ts
@@ -16,6 +16,7 @@ import { isCookieTrue } from '@/utils/cookie-utils';
 import { DesignCodes, DesignModeTriggers } from '@/utils/design-codes';
 import { handleSkipLogin as skipLoginUtil } from '@/utils/login-handler';
 import { getPushSubscription } from '@/utils/push-notifications/push-manager-utils';
+import { isNativeAppWebView } from '@/utils/standalone-check';
 import Cookies from 'js-cookie';
 import { useSession } from 'next-auth/react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
@@ -115,6 +116,9 @@ export const useOnboarding = (): UseOnboardingReturn => {
     const hasSkipped = isCookieTrue(Cookie.SKIP_PUSH_NOTIFICATION);
     if (hasSkipped) {
       dispatch({ type: OnboardingAction.USER_ACTION_SKIP_PUSH });
+    } else if (isNativeAppWebView()) {
+      // Native push was granted via FCM — no Web Push subscription exists, advance directly
+      dispatch({ type: OnboardingAction.UPDATE_CONTEXT, payload: { hasPushSubscription: true } });
     } else {
       // Refresh push subscription status and update context
       void getPushSubscription().then((sub) => {


### PR DESCRIPTION
## Problem

The onboarding push step was permanently stuck for users running the native KonektaApp on iOS. Two bugs combined to produce the hang:

1. **No system dialog**: The native app requested iOS push permission with `provisional: true` (fixed in the konekta-app repo), which grants silently without showing the user a dialog. The user tapped "Enable" and nothing visually happened.

2. **FSM never advanced**: `handlePushNotification` — the callback called after the native push UI step completes — always checked `getPushSubscription()` (the Web Push API). In the native WebView there is no Web Push subscription, so `hasPushSubscription` remained `false`, `determineNextStep` kept returning `PushNotifications`, and the onboarding never moved forward. The user would see the "Enable" button reappear and could tap indefinitely with no effect.

## Changes

### Core fix
- **`use-onboarding.ts`**: `handlePushNotification` now detects native mode via `isNativeAppWebView()` and dispatches `hasPushSubscription: true` directly, bypassing the web push subscription check that has no meaning in the native context.

### Native push UI routing (prerequisite)
- **`native-push-subscription-manager.tsx`** (new): Dedicated onboarding component for the native push path. Shows "Enable" / "Open Settings" UI, auto-advances on mount if permission is already granted, handles denied state, and resets the requesting spinner correctly on dismissal.
- **`push-notification-subscription-manager.tsx`**: Routes to `NativePushSubscriptionManager` when running inside the KonektaApp WebView; falls back to the existing Web Push flow for browser installs. Web Push hook is always called to keep hook call order stable.

### Observability
- **`use-native-push.ts`**: Structured `[NativePush:PWA]` log prefixes throughout; `registerDevice`/`unregisterDevice` now log success and failure separately.
- **`native-push-router.ts`**: Structured `[NativePush:API]` log prefixes; logs deduplication counts and user IDs for register/unregister mutations.

## Test plan

- [ ] Native app (iOS): complete onboarding → push step shows "Enable" → tap → system permission dialog appears → grant → onboarding advances past push step
- [ ] Native app (iOS): push step auto-advances if permission was already granted in a previous session
- [ ] Native app (iOS): deny permission → "Enable them in device settings" message appears with "Open Settings" button
- [ ] Browser (Chrome/Safari): push step shows existing Web Push subscription UI, unaffected

## Related

Companion fix in konekta-app: `fix/native-push-ios-permission` — changes `provisional: false` so iOS shows the system dialog, and removes a redundant `waitForApnsToken()` call that doubled the maximum spinner wait from 5 s to 10 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)