### PR TITLE
fix(onboarding): prevent sync effect from resetting native push state

### DIFF
--- a/src/features/onboarding/hooks/use-onboarding.ts
+++ b/src/features/onboarding/hooks/use-onboarding.ts
@@ -92,7 +92,10 @@ export const useOnboarding = (): UseOnboardingReturn => {
         offlineContentHandled,
         hasCachedContent,
         pushPermission,
-        hasPushSubscription,
+        // In native mode, hasPushSubscription is managed exclusively by handlePushNotification.
+        // Excluding it here prevents async re-runs of this effect (triggered by hasCachedContent
+        // or other deps) from overwriting the true value set after native push is granted.
+        ...(isNativeAppWebView() ? {} : { hasPushSubscription }),
       },
     });
   }, [status, isOnline, offlineContentHandled, hasCachedContent, hasPushSubscription]);


### PR DESCRIPTION
## Problem

Even with the fix from #1264 in place (`handlePushNotification` dispatching `hasPushSubscription: true` for native mode), the onboarding still did not advance past the push step.

**Root cause:** A race condition between `handlePushNotification` and the sync effect in `useOnboarding`.

The sync effect re-syncs FSM context whenever any of its deps change:
```
[status, isOnline, offlineContentHandled, hasCachedContent, hasPushSubscription]
```

`hasCachedContent` is set asynchronously by `useOnboardingStorage`, which checks the service worker cache via `caches.open()`. On a returning device the WKWebView already has cached pages, so this resolves quickly and triggers a re-run of the sync effect — typically within the same render cycle as the push permission grant.

When the sync effect re-ran, it sent `hasPushSubscription: false` (from the web push hook, which always returns `false` in native mode) back to the FSM, overwriting the `true` that `handlePushNotification` had just set. The FSM jumped back to `PushNotifications`.

## Fix

Exclude `hasPushSubscription` from the sync effect payload when running inside the native WebView. In native mode, `hasPushSubscription` in the FSM is owned exclusively by `handlePushNotification` — the sync effect must never touch it.

```ts
...(isNativeAppWebView() ? {} : { hasPushSubscription }),
```

`hasPushSubscription` remains in the deps array (web push state can still trigger re-runs in browser mode), but in native mode its value is simply not written into the FSM context on those re-runs.

## Scenarios verified

| Scenario | Before | After |
|---|---|---|
| First grant (native) | FSM reset to push step by hasCachedContent resolving | FSM advances and stays advanced ✓ |
| Already granted (native, second launch) | Same reset race | Auto-advances via getStatus() on mount ✓ |
| Skip push (native) | Unaffected (cookie path) | Unaffected ✓ |
| Web browser | Unaffected | Unaffected ✓ |

## Related

- Builds on #1264 (`handlePushNotification` native branch + `NativePushSubscriptionManager`)
- Companion native fix: cevi/konekta-app#20

🤖 Generated with [Claude Code](https://claude.com/claude-code)